### PR TITLE
Move to Unsigned Integer for Text Length

### DIFF
--- a/src/Firethorn/GreenTree.fs
+++ b/src/Firethorn/GreenTree.fs
@@ -41,7 +41,7 @@ and GreenToken =
     static member Create(kind: SyntaxKind, text: string) = { Kind = kind; Text = text }
 
     /// Get the width of the single token.
-    member self.TextLength =  uint32 self.Text.Length
+    member self.TextLength = uint32 self.Text.Length
 
     /// Custom string representation for tokens.
     override self.ToString() =

--- a/src/Firethorn/GreenTree.fs
+++ b/src/Firethorn/GreenTree.fs
@@ -41,7 +41,7 @@ and GreenToken =
     static member Create(kind: SyntaxKind, text: string) = { Kind = kind; Text = text }
 
     /// Get the width of the single token.
-    member self.TextLength = self.Text.Length
+    member self.TextLength =  uint32 self.Text.Length
 
     /// Custom string representation for tokens.
     override self.ToString() =

--- a/src/Firethorn/RedTree.fs
+++ b/src/Firethorn/RedTree.fs
@@ -23,7 +23,7 @@ type SyntaxNode =
     /// Create a new root syntax node from an underlying green node.
     static member CreateRoot(node: GreenNode) =
         { Parent = None
-          Offset = 0
+          Offset = 0u
           Green = node }
 
     /// Get the kind of the underlying green node.

--- a/src/Firethorn/Text.fs
+++ b/src/Firethorn/Text.fs
@@ -10,4 +10,4 @@ type TextRange =
       End: TextLength }
 
     // Custom string representation for text ranges.
-    override self.ToString() = sprintf "%d..%d" self.Start self.End
+    override self.ToString() = sprintf "%u..%u" self.Start self.End

--- a/src/Firethorn/Text.fs
+++ b/src/Firethorn/Text.fs
@@ -4,6 +4,7 @@ namespace Firethorn
 type TextLength = uint32
 
 /// A range of positions in source text.
+[<Struct>]
 type TextRange =
     { Start: TextLength
       End: TextLength }

--- a/src/Firethorn/Text.fs
+++ b/src/Firethorn/Text.fs
@@ -1,7 +1,7 @@
 namespace Firethorn
 
 /// A position in source text.
-type TextLength = int
+type TextLength = uint32
 
 /// A range of positions in source text.
 type TextRange =

--- a/test/Firethorn.Tests/GreenTreeTests.fs
+++ b/test/Firethorn.Tests/GreenTreeTests.fs
@@ -10,11 +10,11 @@ open System
 [<Fact>]
 let ``Create token has expected widths`` () =
     let plus = GreenToken.Create(SyntaxKind 1, "+")
-    Assert.Equal(1, plus.TextLength)
+    Assert.Equal(1u, plus.TextLength)
 
     let quote = GreenToken.Create(SyntaxKind 10, "quote")
 
-    Assert.Equal(5, quote.TextLength)
+    Assert.Equal(5u, quote.TextLength)
 
 
 [<Fact>]
@@ -29,7 +29,7 @@ let ``Create token exposes kind`` () =
 [<Fact>]
 let ``Green node has correct length`` () =
     let empty = GreenNode.Create(SyntaxKind 10, [])
-    Assert.Equal(0, empty.TextLength)
+    Assert.Equal(0u, empty.TextLength)
 
     let mulForm =
         GreenNode.Create(
@@ -41,7 +41,7 @@ let ``Green node has correct length`` () =
               GreenToken.Create(SyntaxKind 5, ")") |> Token ]
         )
 
-    Assert.Equal(7, mulForm.TextLength)
+    Assert.Equal(7u, mulForm.TextLength)
 
 [<Fact>]
 let ``Green trees can share nodes`` () =
@@ -66,7 +66,7 @@ let ``Green trees can share nodes`` () =
     //      +---+-----+--+--+----+
     //      |   |      \   /     |
     //   Open  Mul      Two    Close
-    Assert.Equal(5, mulForm.TextLength)
+    Assert.Equal(5u, mulForm.TextLength)
 
     let additionForm =
         GreenNode.Create(
@@ -87,7 +87,7 @@ let ``Green trees can share nodes`` () =
     //      +---+-----+--+--+----+
     //          |      \   /
     //         Mul      Two
-    Assert.Equal(13, additionForm.TextLength)
+    Assert.Equal(13u, additionForm.TextLength)
 
 [<Fact>]
 let ``Green tokens are structurally equal`` () =

--- a/test/Firethorn.Tests/RedTreeTests.fs
+++ b/test/Firethorn.Tests/RedTreeTests.fs
@@ -12,7 +12,7 @@ let ``Create red tree from root node`` () =
     let green = GreenNode.Create(SyntaxKind 0, [])
     let syntaxRoot = SyntaxNode.CreateRoot(green)
 
-    Assert.Equal(0, syntaxRoot.Offset)
+    Assert.Equal(0u, syntaxRoot.Offset)
     Assert.Equal(None, syntaxRoot.Parent)
 
 [<Fact>]
@@ -29,15 +29,15 @@ let ``Create red tree with children`` () =
 
     let root = SyntaxNode.CreateRoot(green)
 
-    Assert.Equal(0, root.Offset)
+    Assert.Equal(0u, root.Offset)
     Assert.Equal(None, root.Parent)
 
     let literals = root.Children() |> Seq.filter (fun x -> x.Kind = SyntaxKind 5)
 
     Assert.Collection(
         literals,
-        new Action<SyntaxNode>(fun x -> Assert.Equal(2, x.Offset)),
-        new Action<SyntaxNode>(fun x -> Assert.Equal(3, x.Offset))
+        new Action<SyntaxNode>(fun x -> Assert.Equal(2u, x.Offset)),
+        new Action<SyntaxNode>(fun x -> Assert.Equal(3u, x.Offset))
     )
 
     Assert.Empty(root.Children() |> Seq.filter (fun x -> x.Kind = SyntaxKind 1))


### PR DESCRIPTION
Text offsets and lengths shouldn't ever be negative. Use a more compact representation for them. We don't need 4GB buffers for this library so uint32 is sufficient for representing text lengths and offsets.

This pull request standardizes the representation of text positions and lengths in the codebase by switching from `int` to `uint32` for types like `TextLength` and related fields. This change propagates through the core data structures and their usage, including updates to constructors, properties, and tests to ensure type consistency and improved safety for handling source text positions.

**Core type and API changes:**

* Changed the `TextLength` type from `int` to `uint32` in `src/Firethorn/Text.fs`, and updated the `TextRange` struct accordingly.
* Updated the `TextLength` property of `GreenToken` in `src/Firethorn/GreenTree.fs` to return a `uint32` value.
* Modified the `Offset` field in the `SyntaxNode` type and its `CreateRoot` method to use `uint32` instead of `int` in `src/Firethorn/RedTree.fs`.

**Test updates for type consistency:**

* Updated all relevant test assertions in `test/Firethorn.Tests/GreenTreeTests.fs` and `test/Firethorn.Tests/RedTreeTests.fs` to compare against `uint32` values instead of `int`. [[1]](diffhunk://#diff-1e396295736ceb2af22f9910dc51b617627fbc18b402cd9cb864c17784536b3aL13-R17) [[2]](diffhunk://#diff-1e396295736ceb2af22f9910dc51b617627fbc18b402cd9cb864c17784536b3aL32-R32) [[3]](diffhunk://#diff-1e396295736ceb2af22f9910dc51b617627fbc18b402cd9cb864c17784536b3aL44-R44) [[4]](diffhunk://#diff-1e396295736ceb2af22f9910dc51b617627fbc18b402cd9cb864c17784536b3aL69-R69) [[5]](diffhunk://#diff-1e396295736ceb2af22f9910dc51b617627fbc18b402cd9cb864c17784536b3aL90-R90) [[6]](diffhunk://#diff-cb70621fd17851af29895d275ddb75786f8fb39beb8a1a8fc0e454338124abd8L15-R15) [[7]](diffhunk://#diff-cb70621fd17851af29895d275ddb75786f8fb39beb8a1a8fc0e454338124abd8L32-R40)

These changes ensure that text position and length calculations are non-negative and consistent throughout the codebase, reducing the risk of bugs related to negative indices or overflows.