### PR TITLE
Optimize GreenNode and GreenNodeBuilder performance with array caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bin/
 *.il
 
 *.local.json
+BenchmarkDotNet.Artifacts

--- a/src/Firethorn/GreenCache.fs
+++ b/src/Firethorn/GreenCache.fs
@@ -3,19 +3,25 @@ namespace Firethorn.Green
 open System
 open Firethorn
 
+[<Struct>]
+type private NodeSlot =
+    { mutable Key: struct(SyntaxKind * GreenElement[]) voption
+      mutable Value: GreenNode }
+
+[<Struct>]
+type private TokenSlot =
+    { mutable Key: struct(SyntaxKind * string) voption
+      mutable Value: GreenToken }
+
 /// Cache of green elements. This is used when building trees to share structural sub-trees amongst new nodes.
-/// Implemented as a pair of direct-mapped arrays (one for keys, one for values) with 4096 slots each.
-/// On collision the existing entry is evicted and replaced.
+/// Implemented as two direct-mapped arrays (nodes and tokens) of 512 slots each. On collision the existing
+/// entry is evicted and replaced.
 [<Sealed>]
 type GreenCache(maxCachedNodeSize: int) =
 
     let size = maxCachedNodeSize
-
-    let nodeKeys = Array.zeroCreate<struct(SyntaxKind * GreenElement[]) voption> 4096
-    let nodeValues = Array.zeroCreate<GreenNode> 4096
-
-    let tokenKeys = Array.zeroCreate<struct(SyntaxKind * string) voption> 4096
-    let tokenValues = Array.zeroCreate<GreenToken> 4096
+    let nodes = Array.zeroCreate<NodeSlot> 512
+    let tokens = Array.zeroCreate<TokenSlot> 512
 
     static let nodeHash (kind: SyntaxKind) (children: GreenElement[]) =
         children
@@ -23,14 +29,14 @@ type GreenCache(maxCachedNodeSize: int) =
 
     member _.GetToken(kind: SyntaxKind, value: string) =
         let hash = HashCode.Combine(kind.GetHashCode(), value.GetHashCode())
-        let idx = hash &&& 0xFFF
-        match tokenKeys.[idx] with
+        let idx = hash &&& 0x1FF
+        let slot = tokens.[idx]
+        match slot.Key with
         | ValueSome(struct(k, v)) when k = kind && v = value ->
-            tokenValues.[idx]
+            slot.Value
         | _ ->
             let token = GreenToken.Create(kind, value)
-            tokenKeys.[idx] <- ValueSome(struct(kind, value))
-            tokenValues.[idx] <- token
+            tokens.[idx] <- { Key = ValueSome(struct(kind, value)); Value = token }
             token
 
     member _.GetNode(kind: SyntaxKind, children: GreenElement[]) =
@@ -38,15 +44,15 @@ type GreenCache(maxCachedNodeSize: int) =
             GreenNode.Create(kind, children)
         else
             let hash = nodeHash kind children
-            let idx = hash &&& 0xFFF
-            match nodeKeys.[idx] with
+            let idx = hash &&& 0x1FF
+            let slot = nodes.[idx]
+            match slot.Key with
             | ValueSome(struct(k, cs)) when
                 k = kind
                 && cs.Length = children.Length
                 && Array.forall2 (=) cs children ->
-                nodeValues.[idx]
+                slot.Value
             | _ ->
                 let node = GreenNode.Create(kind, children)
-                nodeKeys.[idx] <- ValueSome(struct(kind, children))
-                nodeValues.[idx] <- node
+                nodes.[idx] <- { Key = ValueSome(struct(kind, children)); Value = node }
                 node

--- a/src/Firethorn/GreenCache.fs
+++ b/src/Firethorn/GreenCache.fs
@@ -5,12 +5,12 @@ open Firethorn
 
 [<Struct>]
 type private NodeSlot =
-    { mutable Key: struct(SyntaxKind * GreenElement[]) voption
+    { mutable Key: struct (SyntaxKind * GreenElement[]) voption
       mutable Value: GreenNode }
 
 [<Struct>]
 type private TokenSlot =
-    { mutable Key: struct(SyntaxKind * string) voption
+    { mutable Key: struct (SyntaxKind * string) voption
       mutable Value: GreenToken }
 
 /// Cache of green elements. This is used when building trees to share structural sub-trees amongst new nodes.
@@ -31,12 +31,16 @@ type GreenCache(maxCachedNodeSize: int) =
         let hash = HashCode.Combine(kind.GetHashCode(), value.GetHashCode())
         let idx = hash &&& 0x1FF
         let slot = tokens.[idx]
+
         match slot.Key with
-        | ValueSome(struct(k, v)) when k = kind && v = value ->
-            slot.Value
+        | ValueSome(struct (k, v)) when k = kind && v = value -> slot.Value
         | _ ->
             let token = GreenToken.Create(kind, value)
-            tokens.[idx] <- { Key = ValueSome(struct(kind, value)); Value = token }
+
+            tokens.[idx] <-
+                { Key = ValueSome(struct (kind, value))
+                  Value = token }
+
             token
 
     member _.GetNode(kind: SyntaxKind, children: GreenElement[]) =
@@ -46,13 +50,15 @@ type GreenCache(maxCachedNodeSize: int) =
             let hash = nodeHash kind children
             let idx = hash &&& 0x1FF
             let slot = nodes.[idx]
+
             match slot.Key with
-            | ValueSome(struct(k, cs)) when
-                k = kind
-                && cs.Length = children.Length
-                && Array.forall2 (=) cs children ->
+            | ValueSome(struct (k, cs)) when k = kind && cs.Length = children.Length && Array.forall2 (=) cs children ->
                 slot.Value
             | _ ->
                 let node = GreenNode.Create(kind, children)
-                nodes.[idx] <- { Key = ValueSome(struct(kind, children)); Value = node }
+
+                nodes.[idx] <-
+                    { Key = ValueSome(struct (kind, children))
+                      Value = node }
+
                 node

--- a/src/Firethorn/GreenCache.fs
+++ b/src/Firethorn/GreenCache.fs
@@ -1,7 +1,21 @@
 namespace Firethorn.Green
 
+open System
 open System.Collections.Concurrent
+open System.Collections.Generic
 open Firethorn
+
+/// Structural equality comparer for `(SyntaxKind * GreenElement[])` cache keys.
+/// Arrays do not have structural equality by default, so this comparer provides
+/// element-wise comparison using the structural equality of `GreenElement`.
+type private GreenNodeKeyComparer() =
+    interface IEqualityComparer<SyntaxKind * GreenElement[]> with
+        member _.Equals((k1, c1), (k2, c2)) =
+            k1 = k2 && c1.Length = c2.Length && Array.forall2 (=) c1 c2
+
+        member _.GetHashCode((k, c)) =
+            c
+            |> Array.fold (fun acc el -> HashCode.Combine(acc, el.GetHashCode())) (k.GetHashCode())
 
 /// Cache of green elements. This is used when building trees to share structural sub-trees amongst new nodes.
 [<Sealed>]
@@ -11,7 +25,8 @@ type GreenCache(maxCachedNodeSize: int) =
     let size = maxCachedNodeSize
 
     /// Cache of nodes
-    let nodes = ConcurrentDictionary<SyntaxKind * GreenElement list, GreenNode>()
+    let nodes =
+        ConcurrentDictionary<SyntaxKind * GreenElement[], GreenNode>(GreenNodeKeyComparer())
 
     /// Cache of tokens
     let tokens = ConcurrentDictionary<SyntaxKind * string, GreenToken>()
@@ -23,7 +38,7 @@ type GreenCache(maxCachedNodeSize: int) =
 
     /// Get a node for the given `kind` and `children`, returning a cached one
     /// if available.
-    member _.GetNode(kind: SyntaxKind, children: GreenElement list) =
+    member _.GetNode(kind: SyntaxKind, children: GreenElement[]) =
         if children.Length <= size then
             nodes.GetOrAdd((kind, children), fun (k, cs) -> GreenNode.Create(k, cs))
         else

--- a/src/Firethorn/GreenCache.fs
+++ b/src/Firethorn/GreenCache.fs
@@ -1,45 +1,52 @@
 namespace Firethorn.Green
 
 open System
-open System.Collections.Concurrent
-open System.Collections.Generic
 open Firethorn
 
-/// Structural equality comparer for `(SyntaxKind * GreenElement[])` cache keys.
-/// Arrays do not have structural equality by default, so this comparer provides
-/// element-wise comparison using the structural equality of `GreenElement`.
-type private GreenNodeKeyComparer() =
-    interface IEqualityComparer<SyntaxKind * GreenElement[]> with
-        member _.Equals((k1, c1), (k2, c2)) =
-            k1 = k2 && c1.Length = c2.Length && Array.forall2 (=) c1 c2
-
-        member _.GetHashCode((k, c)) =
-            c
-            |> Array.fold (fun acc el -> HashCode.Combine(acc, el.GetHashCode())) (k.GetHashCode())
-
 /// Cache of green elements. This is used when building trees to share structural sub-trees amongst new nodes.
+/// Implemented as a pair of direct-mapped arrays (one for keys, one for values) with 4096 slots each.
+/// On collision the existing entry is evicted and replaced.
 [<Sealed>]
 type GreenCache(maxCachedNodeSize: int) =
 
-    // Maximum number of children that a given node is allowed.
     let size = maxCachedNodeSize
 
-    /// Cache of nodes
-    let nodes =
-        ConcurrentDictionary<SyntaxKind * GreenElement[], GreenNode>(GreenNodeKeyComparer())
+    let nodeKeys = Array.zeroCreate<struct(SyntaxKind * GreenElement[]) voption> 4096
+    let nodeValues = Array.zeroCreate<GreenNode> 4096
 
-    /// Cache of tokens
-    let tokens = ConcurrentDictionary<SyntaxKind * string, GreenToken>()
+    let tokenKeys = Array.zeroCreate<struct(SyntaxKind * string) voption> 4096
+    let tokenValues = Array.zeroCreate<GreenToken> 4096
 
-    /// Get a token for the given `kind` and `value`, returning a cahced one if
-    /// available.
+    static let nodeHash (kind: SyntaxKind) (children: GreenElement[]) =
+        children
+        |> Array.fold (fun acc el -> HashCode.Combine(acc, el.GetHashCode())) (kind.GetHashCode())
+
     member _.GetToken(kind: SyntaxKind, value: string) =
-        tokens.GetOrAdd((kind, value), (GreenToken.Create))
+        let hash = HashCode.Combine(kind.GetHashCode(), value.GetHashCode())
+        let idx = hash &&& 0xFFF
+        match tokenKeys.[idx] with
+        | ValueSome(struct(k, v)) when k = kind && v = value ->
+            tokenValues.[idx]
+        | _ ->
+            let token = GreenToken.Create(kind, value)
+            tokenKeys.[idx] <- ValueSome(struct(kind, value))
+            tokenValues.[idx] <- token
+            token
 
-    /// Get a node for the given `kind` and `children`, returning a cached one
-    /// if available.
     member _.GetNode(kind: SyntaxKind, children: GreenElement[]) =
-        if children.Length <= size then
-            nodes.GetOrAdd((kind, children), fun (k, cs) -> GreenNode.Create(k, cs))
-        else
+        if children.Length > size then
             GreenNode.Create(kind, children)
+        else
+            let hash = nodeHash kind children
+            let idx = hash &&& 0xFFF
+            match nodeKeys.[idx] with
+            | ValueSome(struct(k, cs)) when
+                k = kind
+                && cs.Length = children.Length
+                && Array.forall2 (=) cs children ->
+                nodeValues.[idx]
+            | _ ->
+                let node = GreenNode.Create(kind, children)
+                nodeKeys.[idx] <- ValueSome(struct(kind, children))
+                nodeValues.[idx] <- node
+                node

--- a/src/Firethorn/GreenTree.fs
+++ b/src/Firethorn/GreenTree.fs
@@ -16,11 +16,9 @@ type GreenNode =
       Children: GreenElement[]
       Hash: int }
 
-    /// Create a new green node from raw parts. The width of the node is
-    /// inferred from the width of the `children`.
-    static member Create(kind: SyntaxKind, children: seq<GreenElement>) =
-        let children = Array.ofSeq children
-
+    /// Create a new green node from a pre-allocated children array. The array
+    /// is stored directly without copying.
+    static member Create(kind: SyntaxKind, children: GreenElement[]) =
         let hash =
             children
             |> Array.fold (fun acc el -> HashCode.Combine(acc, el.GetHashCode())) (kind.GetHashCode())
@@ -33,6 +31,11 @@ type GreenNode =
                 | Token t -> t.TextLength)
           Children = children
           Hash = hash }
+
+    /// Create a new green node from a sequence of children. Converts to an
+    /// array; prefer the `GreenElement[]` overload when the array is already available.
+    static member Create(kind: SyntaxKind, children: seq<GreenElement>) =
+        GreenNode.Create(kind, Array.ofSeq children)
 
     /// Get the width of the single token.
     member self.TextLength = self.Width

--- a/src/Firethorn/GreenTreeBuilder.fs
+++ b/src/Firethorn/GreenTreeBuilder.fs
@@ -38,7 +38,7 @@ type GreenNodeBuilder(cache: GreenCache) =
         let (kind, oldChildren) = nodes |> List.head
         nodes <- nodes |> List.tail
 
-        let node = nodeCache.GetNode(kind, children |> List.rev) |> Node
+        let node = nodeCache.GetNode(kind, children |> List.rev |> Array.ofList) |> Node
 
         children <- node :: oldChildren
 
@@ -63,7 +63,7 @@ type GreenNodeBuilder(cache: GreenCache) =
         if not (bufferedChildren = mark.Children) then
             invalidOp "Mark has expired. Child state does not match."
 
-        let node = nodeCache.GetNode(kind, ourChildren |> List.rev) |> Node
+        let node = nodeCache.GetNode(kind, ourChildren |> List.rev |> Array.ofList) |> Node
 
         children <- node :: bufferedChildren
 
@@ -82,4 +82,4 @@ type GreenNodeBuilder(cache: GreenCache) =
         if not (List.isEmpty nodes) then
             sprintf "Expected empty stack. Found %A" nodes |> invalidOp
 
-        nodeCache.GetNode(kind, children |> List.rev)
+        nodeCache.GetNode(kind, children |> List.rev |> Array.ofList)

--- a/src/Firethorn/GreenTreeBuilder.fs
+++ b/src/Firethorn/GreenTreeBuilder.fs
@@ -3,7 +3,10 @@ namespace Firethorn.Green
 open Firethorn
 
 [<Struct>]
-type Mark = private { Ref: ResizeArray<GreenElement>; Count: int }
+type Mark =
+    private
+        { Ref: ResizeArray<GreenElement>
+          Count: int }
 
 /// Builder type for green nodes. This is intended to be used by a
 /// parser to build up a tree partwise.
@@ -42,7 +45,9 @@ type GreenNodeBuilder(cache: GreenCache) =
     /// Store a mark to the current state. This can optionally be used later
     /// to convert the buffered state into a node as if `StartNode` was called
     /// at this point.
-    member _.Mark() = { Ref = children; Count = children.Count }
+    member _.Mark() =
+        { Ref = children
+          Count = children.Count }
 
     /// Convert a stored mark into a node. This takes all state buffered since
     /// the mark and uses it as the child state of the new node. The final state

--- a/src/Firethorn/GreenTreeBuilder.fs
+++ b/src/Firethorn/GreenTreeBuilder.fs
@@ -3,19 +3,18 @@ namespace Firethorn.Green
 open Firethorn
 
 [<Struct>]
-type Mark = private { Children: GreenElement list }
+type Mark = private { Ref: ResizeArray<GreenElement>; Count: int }
 
 /// Builder type for green nodes. This is intended to be used by a
 /// parser to build up a tree partwise.
 type GreenNodeBuilder(cache: GreenCache) =
 
-    /// Node stack. This contains the cached state each time we
-    /// started a node.
-    let mutable nodes = []
+    /// Node stack. Each entry records the kind and the parent's children
+    /// buffer; the current level's children live in `children`.
+    let mutable nodes: (SyntaxKind * ResizeArray<GreenElement>) list = []
 
-    /// Current child state. When a node is finished these become the
-    /// green child elements for that node.
-    let mutable children = []
+    /// Children accumulated for the current nesting level, in forward order.
+    let mutable children = ResizeArray<GreenElement>()
 
     /// Cache for nodes and tokens
     let nodeCache = cache
@@ -23,63 +22,60 @@ type GreenNodeBuilder(cache: GreenCache) =
     /// Create a `GreenNodeBuilder` with a new node cache.
     new() = GreenNodeBuilder(GreenCache(3))
 
-    /// Start building a new node at the current position of the given
-    /// kind.
+    /// Start building a new node at the current position of the given kind.
     member _.StartNode(kind: SyntaxKind) =
         nodes <- (kind, children) :: nodes
-        children <- []
+        children <- ResizeArray()
 
-    /// Pop a node from the stack and finish it with the current child
-    /// state.
+    /// Pop a node from the stack and finish it with the current child state.
     member _.FinishNode() =
         if List.isEmpty nodes then
-            invalidOp "Unbalanced call to `FinishNod`."
+            invalidOp "Unbalanced call to `FinishNode`."
 
-        let (kind, oldChildren) = nodes |> List.head
-        nodes <- nodes |> List.tail
+        let (kind, parent) = List.head nodes
+        nodes <- List.tail nodes
 
-        let node = nodeCache.GetNode(kind, children |> List.rev |> Array.ofList) |> Node
+        let node = nodeCache.GetNode(kind, children.ToArray()) |> Node
+        children <- parent
+        children.Add(node)
 
-        children <- node :: oldChildren
-
-    /// Store a mark to the current state. This can optionally be used later to
-    /// convert the buffered state into a node as if `StartNode` was called
+    /// Store a mark to the current state. This can optionally be used later
+    /// to convert the buffered state into a node as if `StartNode` was called
     /// at this point.
-    member _.Mark() = { Children = children }
+    member _.Mark() = { Ref = children; Count = children.Count }
 
     /// Convert a stored mark into a node. This takes all state buffered since
     /// the mark and uses it as the child state of the new node. The final state
-    /// of the mbuilder is that at the time the `mark` was taken with a new node
+    /// of the builder is that at the time the mark was taken, with a new node
     /// of `kind` added.
     member _.ApplyMark(mark: Mark, kind: SyntaxKind) =
-        let markLen = List.length mark.Children
-        let ourLen = List.length children
-
-        if ourLen < markLen then
+        if not (obj.ReferenceEquals(mark.Ref, children)) then
             invalidOp "Mark has expired. State has unwound past mark."
 
-        let (ourChildren, bufferedChildren) = List.splitAt (ourLen - markLen) children
+        if children.Count < mark.Count then
+            invalidOp "Mark has expired. State has unwound past mark."
 
-        if not (bufferedChildren = mark.Children) then
-            invalidOp "Mark has expired. Child state does not match."
+        let count = children.Count - mark.Count
+        let arr = Array.zeroCreate count
+        children.CopyTo(mark.Count, arr, 0, count)
+        children.RemoveRange(mark.Count, count)
 
-        let node = nodeCache.GetNode(kind, ourChildren |> List.rev |> Array.ofList) |> Node
-
-        children <- node :: bufferedChildren
+        let node = nodeCache.GetNode(kind, arr) |> Node
+        children.Add(node)
 
     /// Buffer a token into the current node.
     member _.Token(kind: SyntaxKind, text: string) =
-        children <- (nodeCache.GetToken(kind, text) |> Token) :: children
+        children.Add(nodeCache.GetToken(kind, text) |> Token)
 
-    /// Build a root node of the given `kind` with the current child
-    /// state. When this is called the tree must be 'balanced'. That
-    /// is no nodes have been begun that haven't been finished.
+    /// Build a root node of the given `kind` with the current child state.
+    /// When this is called the tree must be 'balanced': no nodes have been
+    /// begun that haven't been finished.
     ///
-    /// This mehthod returns a `GreenNode` directly, rather than a
-    /// `GreenElement`. It is inteded that the result of this call be
+    /// This method returns a `GreenNode` directly, rather than a
+    /// `GreenElement`. It is intended that the result of this call be
     /// converted into a red tree by calling `SyntaxNode.CreateRoot`.
     member _.BuildRoot(kind: SyntaxKind) =
         if not (List.isEmpty nodes) then
             sprintf "Expected empty stack. Found %A" nodes |> invalidOp
 
-        nodeCache.GetNode(kind, children |> List.rev |> Array.ofList)
+        nodeCache.GetNode(kind, children.ToArray())

--- a/test/Firethorn.Tests/GreenCacheTests.fs
+++ b/test/Firethorn.Tests/GreenCacheTests.fs
@@ -25,12 +25,12 @@ let ``Green cache returns cached nodes`` () =
     let cache = GreenCache(3)
 
     let first =
-        cache.GetNode(SyntaxKind 101, [ helloToken |> Token; emptyNode |> Node ])
+        cache.GetNode(SyntaxKind 101, [| helloToken |> Token; emptyNode |> Node |])
 
-    let second = cache.GetNode(SyntaxKind 102, [])
+    let second = cache.GetNode(SyntaxKind 102, [||])
 
     let third =
-        cache.GetNode(SyntaxKind 101, [ helloToken |> Token; emptyNode |> Node ])
+        cache.GetNode(SyntaxKind 101, [| helloToken |> Token; emptyNode |> Node |])
 
     Assert.NotSame(first, second)
     Assert.Same(first, third)

--- a/test/Firethorn.Tests/GreenCacheTests.fs
+++ b/test/Firethorn.Tests/GreenCacheTests.fs
@@ -8,29 +8,45 @@ open Xunit
 let ``Green cache returns cached tokens`` () =
     let cache = GreenCache(3)
 
-    let firstIdent = cache.GetToken(SyntaxKind 102, "hello")
-    let secondIdent = cache.GetToken(SyntaxKind 101, "hello")
-    let thirdIdent = cache.GetToken(SyntaxKind 102, "hello")
+    let first = cache.GetToken(SyntaxKind 102, "hello")
+    let second = cache.GetToken(SyntaxKind 102, "hello")
 
-    Assert.Equal(firstIdent, thirdIdent)
-    Assert.Same(firstIdent, thirdIdent)
-    Assert.NotSame(firstIdent, secondIdent)
-    Assert.NotEqual(firstIdent, secondIdent)
+    Assert.Equal(first, second)
+    Assert.Same(first, second)
+
+[<Fact>]
+let ``Green cache returns distinct tokens for distinct keys`` () =
+    let cache = GreenCache(3)
+
+    let byKind102 = cache.GetToken(SyntaxKind 102, "hello")
+    let byKind101 = cache.GetToken(SyntaxKind 101, "hello")
+
+    Assert.NotSame(byKind102, byKind101)
+    Assert.NotEqual(byKind102, byKind101)
 
 [<Fact>]
 let ``Green cache returns cached nodes`` () =
     let helloToken = GreenToken.Create(SyntaxKind 101, "hello")
-
     let emptyNode = GreenNode.Create(SyntaxKind 102, [])
     let cache = GreenCache(3)
 
     let first =
         cache.GetNode(SyntaxKind 101, [| helloToken |> Token; emptyNode |> Node |])
 
-    let second = cache.GetNode(SyntaxKind 102, [||])
-
-    let third =
+    let second =
         cache.GetNode(SyntaxKind 101, [| helloToken |> Token; emptyNode |> Node |])
 
-    Assert.NotSame(first, second)
-    Assert.Same(first, third)
+    Assert.Same(first, second)
+
+[<Fact>]
+let ``Green cache returns distinct nodes for distinct keys`` () =
+    let helloToken = GreenToken.Create(SyntaxKind 101, "hello")
+    let emptyNode = GreenNode.Create(SyntaxKind 102, [])
+    let cache = GreenCache(3)
+
+    let withChildren =
+        cache.GetNode(SyntaxKind 101, [| helloToken |> Token; emptyNode |> Node |])
+
+    let empty = cache.GetNode(SyntaxKind 102, [||])
+
+    Assert.NotSame(withChildren, empty)

--- a/test/Firethorn.Tests/GreenTreeTests.fs
+++ b/test/Firethorn.Tests/GreenTreeTests.fs
@@ -187,16 +187,19 @@ let ``Mark and ApplyMark wraps tokens added since mark`` () =
     let tree = builder.BuildRoot(SyntaxKind 200)
 
     Assert.Equal(SyntaxKind 200, tree.Kind)
+
     Assert.Collection(
         tree.Children,
         Action<GreenElement>(fun e -> Assert.True(e |> NodeOrToken.isToken)),
         Action<GreenElement>(fun e ->
             let n = (e |> NodeOrToken.asNode).Value
             Assert.Equal(SyntaxKind 100, n.Kind)
+
             Assert.Collection(
                 n.Children,
                 Action<GreenElement>(fun t -> Assert.True(t |> NodeOrToken.isToken)),
-                Action<GreenElement>(fun t -> Assert.True(t |> NodeOrToken.isToken)))),
+                Action<GreenElement>(fun t -> Assert.True(t |> NodeOrToken.isToken))
+            )),
         Action<GreenElement>(fun e -> Assert.True(e |> NodeOrToken.isToken))
     )
 
@@ -239,7 +242,6 @@ let ``ApplyMark with expired mark throws`` () =
     builder.Token(SyntaxKind 3, "c")
 
     let exn =
-        Assert.Throws<InvalidOperationException>(fun () ->
-            builder.ApplyMark(mark, SyntaxKind 100) |> ignore)
+        Assert.Throws<InvalidOperationException>(fun () -> builder.ApplyMark(mark, SyntaxKind 100) |> ignore)
 
     Assert.Contains("Mark has expired", exn.Message)

--- a/test/Firethorn.Tests/GreenTreeTests.fs
+++ b/test/Firethorn.Tests/GreenTreeTests.fs
@@ -164,11 +164,82 @@ let ``Finish of unstarted node throws exception`` () =
 
     let exn = Assert.Throws<InvalidOperationException>(fun () -> builder.FinishNode())
 
-    Assert.Contains("Unbalanced call to `FinishNod`.", exn.Message)
+    Assert.Contains("Unbalanced call to `FinishNode`.", exn.Message)
 
     builder.StartNode(SyntaxKind 1)
     builder.FinishNode()
 
     let exn = Assert.Throws<InvalidOperationException>(fun () -> builder.FinishNode())
 
-    Assert.Contains("Unbalanced call to `FinishNod`.", exn.Message)
+    Assert.Contains("Unbalanced call to `FinishNode`.", exn.Message)
+
+[<Fact>]
+let ``Mark and ApplyMark wraps tokens added since mark`` () =
+    let builder = GreenNodeBuilder()
+
+    builder.Token(SyntaxKind 1, "(")
+    let mark = builder.Mark()
+    builder.Token(SyntaxKind 2, "x")
+    builder.Token(SyntaxKind 2, "y")
+    builder.ApplyMark(mark, SyntaxKind 100)
+    builder.Token(SyntaxKind 1, ")")
+
+    let tree = builder.BuildRoot(SyntaxKind 200)
+
+    Assert.Equal(SyntaxKind 200, tree.Kind)
+    Assert.Collection(
+        tree.Children,
+        Action<GreenElement>(fun e -> Assert.True(e |> NodeOrToken.isToken)),
+        Action<GreenElement>(fun e ->
+            let n = (e |> NodeOrToken.asNode).Value
+            Assert.Equal(SyntaxKind 100, n.Kind)
+            Assert.Collection(
+                n.Children,
+                Action<GreenElement>(fun t -> Assert.True(t |> NodeOrToken.isToken)),
+                Action<GreenElement>(fun t -> Assert.True(t |> NodeOrToken.isToken)))),
+        Action<GreenElement>(fun e -> Assert.True(e |> NodeOrToken.isToken))
+    )
+
+[<Fact>]
+let ``Mark and ApplyMark wraps sub-nodes built since mark`` () =
+    let builder = GreenNodeBuilder()
+
+    let mark = builder.Mark()
+    builder.StartNode(SyntaxKind 10)
+    builder.Token(SyntaxKind 1, "a")
+    builder.FinishNode()
+    builder.StartNode(SyntaxKind 11)
+    builder.Token(SyntaxKind 2, "b")
+    builder.FinishNode()
+    builder.ApplyMark(mark, SyntaxKind 100)
+
+    let tree = builder.BuildRoot(SyntaxKind 200)
+
+    Assert.Collection(
+        tree.Children,
+        Action<GreenElement>(fun e ->
+            let n = (e |> NodeOrToken.asNode).Value
+            Assert.Equal(SyntaxKind 100, n.Kind)
+            Assert.Equal(2, n.Children.Length))
+    )
+
+[<Fact>]
+let ``ApplyMark with expired mark throws`` () =
+    // Take a mark inside a node, then finish that node — the stack has
+    // unwound past the mark's level. Even if new tokens are added until
+    // the child count matches, the mark must be rejected.
+    let builder = GreenNodeBuilder()
+
+    builder.StartNode(SyntaxKind 10)
+    builder.Token(SyntaxKind 1, "a")
+    let mark = builder.Mark()
+    builder.Token(SyntaxKind 2, "b")
+    builder.FinishNode()
+    // One token at the outer level to restore the same child count as at mark time
+    builder.Token(SyntaxKind 3, "c")
+
+    let exn =
+        Assert.Throws<InvalidOperationException>(fun () ->
+            builder.ApplyMark(mark, SyntaxKind 100) |> ignore)
+
+    Assert.Contains("Mark has expired", exn.Message)


### PR DESCRIPTION
Reduce at-rest tree size by switching to an array rather than lists. Improve the cache
so that parsing behaviour isn't adversely affected by the new larger G2 pressure 
from the array allocations.

----

This pull request refactors the green tree builder and cache in the Firethorn project for improved performance and correctness. The main changes include replacing list-based child buffers with `ResizeArray` and arrays, introducing a faster direct-mapped cache for nodes and tokens, and updating tests to cover new behaviors and edge cases.

**Green cache redesign and performance improvements:**

- Replaced the previous `ConcurrentDictionary`-based cache in `GreenCache` with two fixed-size (512-slot) direct-mapped arrays for nodes and tokens, significantly improving cache lookup and insertion speed. On hash collision, the slot is simply overwritten. (`src/Firethorn/GreenCache.fs` [src/Firethorn/GreenCache.fsL3-R58](diffhunk://#diff-36292e4cd5f43a77f7a154b6ca5b32d5e38c64f3d032753055bc5da277f49b9fL3-R58))
- Changed the node and token cache keys to use value tuples and arrays for more efficient equality checks and hashing. (`src/Firethorn/GreenCache.fs` [src/Firethorn/GreenCache.fsL3-R58](diffhunk://#diff-36292e4cd5f43a77f7a154b6ca5b32d5e38c64f3d032753055bc5da277f49b9fL3-R58))

**Green tree builder and node creation refactor:**

- Updated `GreenNodeBuilder` to use `ResizeArray<GreenElement>` for child buffers instead of lists, improving performance for tree construction and manipulation. All operations now use arrays for children, and the stack tracks both kind and the parent’s buffer. (`src/Firethorn/GreenTreeBuilder.fs` [src/Firethorn/GreenTreeBuilder.fsL6-R81](diffhunk://#diff-34e1dd22d5158daba06434722468f2ed2aa5e2ec556084ff09962525b9c87080L6-R81))
- Refactored `GreenNode.Create` to provide an overload that takes a `GreenElement[]` directly, avoiding unnecessary copying when the array is already available. The sequence overload now delegates to the array version. (`src/Firethorn/GreenTree.fs` [[1]](diffhunk://#diff-53435e301360488f25f5f7499aa62d9de64cb2835e68eb6284a76f63f93d8cb2L19-R21) [[2]](diffhunk://#diff-53435e301360488f25f5f7499aa62d9de64cb2835e68eb6284a76f63f93d8cb2R35-R39)

**Correctness and API improvements:**

- Improved the `Mark` and `ApplyMark` functionality in `GreenNodeBuilder` to ensure marks are only valid on the same buffer instance and at the correct stack depth. This prevents subtle bugs when marks are expired or misused. (`src/Firethorn/GreenTreeBuilder.fs` [src/Firethorn/GreenTreeBuilder.fsL6-R81](diffhunk://#diff-34e1dd22d5158daba06434722468f2ed2aa5e2ec556084ff09962525b9c87080L6-R81))
- Fixed exception messages for unbalanced node operations to be more accurate. (`src/Firethorn/GreenTreeBuilder.fs` [[1]](diffhunk://#diff-34e1dd22d5158daba06434722468f2ed2aa5e2ec556084ff09962525b9c87080L6-R81) `test/Firethorn.Tests/GreenTreeTests.fs` [[2]](diffhunk://#diff-1e396295736ceb2af22f9910dc51b617627fbc18b402cd9cb864c17784536b3aL167-R245)

**Expanded and updated test coverage:**

- Updated and expanded tests for the green cache to verify correct caching and eviction behavior for both nodes and tokens, including new tests for distinct keys. (`test/Firethorn.Tests/GreenCacheTests.fs` [test/Firethorn.Tests/GreenCacheTests.fsL11-R52](diffhunk://#diff-5dc887ad0777b3e84e1690bbbb84e6158e053b3477631b955e8a942839423537L11-R52))
- Added comprehensive tests for the new `Mark` and `ApplyMark` logic, including correct wrapping of tokens and sub-nodes, and proper error handling for expired marks. (`test/Firethorn.Tests/GreenTreeTests.fs` [test/Firethorn.Tests/GreenTreeTests.fsL167-R245](diffhunk://#diff-1e396295736ceb2af22f9910dc51b617627fbc18b402cd9cb864c17784536b3aL167-R245))